### PR TITLE
Solve isPalindrome by comparing mirroring indices

### DIFF
--- a/String/ValidPalindrome.swift
+++ b/String/ValidPalindrome.swift
@@ -1,43 +1,28 @@
 /**
  * Question Link: https://leetcode.com/problems/valid-palindrome/
- * Primary idea: Two Pointers, compare left and right until they meet
- * 
- * Note: ask interviewer if digit matters
+ * Primary idea: For every index in the first half of the String, compare two values at mirroring indices.
+ *
  * Time Complexity: O(n), Space Complexity: O(n)
  *
  */
 
 class ValidPalindrome {
     func isPalindrome(_ s: String) -> Bool {
-        let chars = Array(s.lowercased().characters)
-  
-        var left = 0
-        var right = chars.count - 1
-  
-        while left < right {
-            while left < right && !isAlpha(chars[left]) {
-                left += 1
-            }
-            while left < right && !isAlpha(chars[right]) {
-                right -= 1
-            }
-    
-            if chars[left] != chars[right] {
+        // Make String into an array of lowercase Characters
+        let characters = s.lowercased().characters
+        
+        // Only keep alphanumeric characters.
+        let cleaned = characters.filter { character in
+            return character.description.rangeOfCharacter(from: CharacterSet.alphanumerics) != nil
+        }
+        
+        // Compare values at mirroring indices.
+        let total = cleaned.count
+        for i in 0 ..< total/2 {
+            if cleaned[i] != cleaned[total - 1 - i] {
                 return false
-            } else {
-                left += 1
-                right -= 1
             }
         }
-  
         return true
-    }
-
-    private func isAlpha(_ char: Character) -> Bool {
-        guard let char = String(char).unicodeScalars.first else {
-            fatalError("Character is invalid")
-        }
-  
-        return CharacterSet.alphanumerics.contains(char)
     }
 }


### PR DESCRIPTION
This PR simplifies `isPalindrome`, which returns whether a String is a palindrome.

Instead of incrementing two pointers in a while loop, we use a for loop to track which indices needs to be compared.

 This also separates the logic for filtering non-alphanumerics from the logic of comparing mirror indices.